### PR TITLE
Fix force-fps bug

### DIFF
--- a/metadrive/engine/core/engine_core.py
+++ b/metadrive/engine/core/engine_core.py
@@ -203,7 +203,7 @@ class EngineCore(ShowBase.ShowBase):
         self.physics_world.dynamic_world.setContactAddedCallback(PythonCallbackObject(collision_callback))
 
         # for real time simulation
-        self.force_fps = ForceFPS(self, start=True)
+        self.force_fps = ForceFPS(self)
 
         # init terrain
         self.terrain = Terrain(self.global_config["show_terrain"])

--- a/metadrive/engine/core/force_fps.py
+++ b/metadrive/engine/core/force_fps.py
@@ -1,19 +1,19 @@
 import time
 
-from metadrive.constants import RENDER_MODE_ONSCREEN
+from metadrive.constants import RENDER_MODE_ONSCREEN, RENDER_MODE_NONE
 
 
 class ForceFPS:
     UNLIMITED = "UnlimitedFPS"
     FORCED = "ForceFPS"
 
-    def __init__(self, engine, start=False):
+    def __init__(self, engine):
         self.engine = engine
         interval = engine.global_config["physics_world_step_size"] \
             if engine.global_config["force_render_fps"] is None else 1 / engine.global_config["force_render_fps"]
         fps = 1 / interval
         self.init_fps = fps
-        if start:
+        if engine.mode == RENDER_MODE_ONSCREEN:
             self.state = self.FORCED
             self.engine.taskMgr.add(self.force_fps_task, "force_fps")
             self.fps = fps


### PR DESCRIPTION
## What changes do you make in this PR?

Force FPS is incorrectly launched when it is ```none_screen``` mode, inducing limited training FPS.

## Checklist

* [ ] I have merged the latest main branch into current branch.
* [ ] I have run `bash scripts/format.sh` before merging.
* Please use "squash and merge" mode.
